### PR TITLE
prometheus functions without registry

### DIFF
--- a/src/prometheus/core.clj
+++ b/src/prometheus/core.clj
@@ -46,23 +46,23 @@
 (defn register-counter
   "Registers a counter to the store and returns the new store."
   [store namespace metric help label-names]
-  (some-> store
-          (as-> $ (assoc-in $ [:metrics namespace metric]
-                            (make-counter (:registry $) namespace metric help label-names)))))
+  (when store
+    (assoc-in store [:metrics namespace metric]
+              (make-counter (:registry store) namespace metric help label-names))))
 
 (defn register-gauge
   "Registers a gauge to the store and returns the new store."
   [store namespace metric help label-names]
-  (some-> store
-          (as-> $ (assoc-in $ [:metrics namespace metric]
-                            (make-gauge (:registry $) namespace metric help label-names)))))
+  (when store
+    (assoc-in store [:metrics namespace metric]
+              (make-gauge (:registry store) namespace metric help label-names))))
 
 (defn register-histogram
   "Registers a histogram to the store and returns the new store."
   [store namespace metric help label-names buckets]
-  (some-> store
-          (as-> $ (assoc-in $ [:metrics namespace metric]
-                            (make-histogram (:registry $) namespace metric help label-names buckets)))))
+  (when store
+    (assoc-in store [:metrics namespace metric]
+              (make-histogram (:registry store) namespace metric help label-names buckets))))
 
 (defn increase-counter
   "Increase the value of a registered counter."

--- a/src/prometheus/example.clj
+++ b/src/prometheus/example.clj
@@ -6,10 +6,10 @@
 
 (defn register-metrics [store]
   (->
-    store
-    (prometheus/register-counter "test" "some_counter" "some test" ["foo"])
-    (prometheus/register-gauge "test" "some_gauge" "some test" ["foo"])
-    (prometheus/register-histogram "test" "some_histogram" "some test" ["foo"] [0.7 0.8 0.9])))
+   store
+   (prometheus/register-counter "test" "some_counter" "some test" ["foo"])
+   (prometheus/register-gauge "test" "some_gauge" "some test" ["foo"])
+   (prometheus/register-histogram "test" "some_histogram" "some test" ["foo"] [0.7 0.8 0.9])))
 
 (defn init! []
   (->> (prometheus/init-defaults)
@@ -22,10 +22,9 @@
   (prometheus/track-observation @store "test" "some_histogram" 0.71 ["bar"])
   (prometheus/dump-metrics (:registry @store)))
 
-
 (defn -main [&]
   (init!)
   (serve
-    (prometheus/instrument-handler handler
-                                   "test_app"
-                                   (:registry @store))))
+   (prometheus/instrument-handler handler
+                                  "test_app"
+                                  (:registry @store))))

--- a/test/prometheus/core_test.clj
+++ b/test/prometheus/core_test.clj
@@ -1,11 +1,11 @@
 (ns prometheus.core-test
   (:require
-    [clojure.test :refer :all]
-    [ring.mock.request :as ring]
-    [prometheus.core :as prometheus])
+   [clojure.test :refer :all]
+   [ring.mock.request :as ring]
+   [prometheus.core :as prometheus])
   (:import
-    (io.prometheus.client CollectorRegistry)
-    (io.prometheus.client.exporter.common TextFormat)))
+   (io.prometheus.client CollectorRegistry)
+   (io.prometheus.client.exporter.common TextFormat)))
 
 (defn test-handler [request]
   (prometheus/with-path request {:status 200 :body "ok"}))
@@ -38,12 +38,12 @@
                        "test_my_custom_gauge{foo=\"bar\",} 101.0"))))
     (testing "adds a custom histogram"
       (let [store (prometheus/register-histogram
-                    store
-                    "test"
-                    "my_custom_histogram"
-                    "some histogram"
-                    ["foo"]
-                    [10 90 100])]
+                   store
+                   "test"
+                   "my_custom_histogram"
+                   "some histogram"
+                   ["foo"]
+                   [10 90 100])]
         (prometheus/track-observation store "test" "my_custom_histogram" 87 ["bar"])
         (is (.contains (:body (prometheus/dump-metrics registry))
                        "test_my_custom_histogram_bucket{foo=\"bar\",le=\"90.0\",} 1.0"))
@@ -53,3 +53,15 @@
                        "test_my_custom_histogram_sum{foo=\"bar\",} 87.0"))
         (is (.contains (:body (prometheus/dump-metrics registry))
                        "test_my_custom_histogram_count{foo=\"bar\",} 1.0"))))))
+
+(deftest without-registry
+  (let [store nil]
+    (testing "registers must behaves like no operation - do nothing"
+      (is (nil? (prometheus/register-counter store "test" "my_custom_counter" "some counter" ["foo"])))
+      (is (nil? (prometheus/register-gauge store "test" "my_custom_gauge" "some gauge" ["foo"])))
+      (is (nil? (prometheus/register-histogram store "test" "histogram" "histogram" ["foo"] [10 90 100]))))
+
+    (testing "metrics update must behaves like no operation - do nothing"
+      (is (nil? (prometheus/increase-counter store "test" "my_custom_counter" ["bar"])))
+      (is (nil? (prometheus/set-gauge store "test" "my_custom_gauge" 101 ["bar"])))
+      (is (nil? (prometheus/track-observation store "test" "my_custom_histogram" 87 ["bar"]))))))


### PR DESCRIPTION
this PR intend to make prometheus-clj functions to not blows up when registry is nil. 

both metrics functions and registers will behaves like noop.

besides that I've **cljfmt** the whole codebase